### PR TITLE
修复 Trying other mirrors 超时错误

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,12 +5,14 @@ $centos_script = <<-SCRIPT
 mv /etc/yum.repos.d /etc/yum.repos.d.orig.$(date -Iseconds)
 mkdir -p /etc/yum.repos.d/
 wget -qO /etc/yum.repos.d/CentOS-Base.repo http://mirrors.aliyun.com/repo/Centos-7.repo
+sed -i -e '/mirrors.cloud.aliyuncs.com/d' -e '/mirrors.aliyuncs.com/d' /etc/yum.repos.d/CentOS-Base.repo
 SCRIPT
 
 $rhel7_script = <<-SCRIPT
 mv /etc/yum.repos.d /etc/yum.repos.d.orig.$(date -Iseconds)
 mkdir -p /etc/yum.repos.d/
 wget -qO /etc/yum.repos.d/CentOS-Base.repo http://mirrors.aliyun.com/repo/Centos-7.repo
+sed -i -e '/mirrors.cloud.aliyuncs.com/d' -e '/mirrors.aliyuncs.com/d' /etc/yum.repos.d/CentOS-Base.repo
 sed -i 's/$releasever/7/g' /etc/yum.repos.d/CentOS-Base.repo
 sed -i 's/PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config
 systemctl restart sshd


### PR DESCRIPTION
修复 CentOS 和 RHEL 下阿里云镜像在安装软件包是出现超时的错误：
```
http://mirrors.aliyuncs.com/centos/7/os/x86_64/repodata/04efe80d41ea3d94d36294f7107709d1c8f70db11e152d6ef562da344748581a-primary.sqlite.bz2: [Errno 12] Timeout on http://mirrors.aliyuncs.com/centos/7/os/x86_64/repodata/04efe80d41ea3d94d36294f7107709d1c8f70db11e152d6ef562da344748581a-primary.sqlite.bz2: (28, 'Connection timed out after 30001 milliseconds')
Trying other mirror.
```